### PR TITLE
Tweaking comment formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,17 +287,16 @@ Use comments to:
 
 - Explain design or architectural decisions, to make notes so that any developers modifying, extending or debugging the code can do so understanding your original decisions.
 
-- Divide up groups of declarations.
+- Divide up groups of declarations using standard block and single line comment formats. (_If you have too many major sections in your partial, perhaps it should be more than one partial!_)
 
     ```
-    // =======================================
-    //  Major Section
-    // =======================================
+    /**
+     * This is a "block" comment carrying a bit more weight
+     * Maybe it has multiple lines
+     * It normally announces a new section of some kind
+     */
 
-    // ------------------------------
-    // Minor section
-
-    // Explanation
+    // Single line explanation of something
     ```
 
 Use multiline comments if you want the comment to be preserved in the compiled CSS.
@@ -680,7 +679,7 @@ Comment your code.  There are two reasons why you should comment:
 - Inline comments explain design or architectural decisions that cannot be conveyed in code alone.  These are mainly for the benefit of other developers modifying, extending or debugging the code, but also for you - you may return to the code a week later and wonder how it works.
 
     ```
-    /*
+    /**
      * I am a nicely formatted comment
      */
 

--- a/README.md
+++ b/README.md
@@ -290,10 +290,18 @@ Use comments to:
 - Divide up groups of declarations using standard block and single line comment formats. (_If you have too many major sections in your partial, perhaps it should be more than one partial!_)
 
     ```
+    /*
+     * This is a "block" comment carrying a bit more weight
+     * Maybe it has multiple lines
+     * It often announces a new section of some kind
+     */
+    
     /**
      * This is a "block" comment carrying a bit more weight
      * Maybe it has multiple lines
-     * It normally announces a new section of some kind
+     * It often announces a new section, perhaps a function
+     * This can be used in JS to denote a JSDoc block
+     * @see http://usejsdoc.org/about-getting-started.html#adding-documentation-comments-to-your-code
      */
 
     // Single line explanation of something


### PR DESCRIPTION
My feeling is that these comment formats are a throwback to the days of long CSS files when partials didn't exist and TOCs were cool. I don't think we need this many different comment formats any more, so I propose that we switch to comment formats that are simpler and consistent with those found in most other languages. 

The current commenting formats aren't actually being followed consistently and quite a few variations can be found hanging about, I think in part because they are too complex. Most editors will (or can easily be made to) autocomplete these formats making them easy to author consistently.

    /**
     * This is a "block" comment carrying a bit more weight
     * Maybe it has multiple lines
     * It normally announces a new section of some kind
     */

    // Single line explanation of something

Feel free to disagree :-)