### PR TITLE
Requesting a preference for single quotes over double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,19 @@ The presence of the attribute itself implies that the value is "true", an absenc
 
 - Use the `===` comparison operator to avoid having to deal with type coercion complications.
 
-- Use quotation marks consistently, e.g. only use single or double quotes throughout your code, don't mix.
+- Use quotation marks consistently, e.g. only use single or double quotes throughout your code, don't mix. Unless there is a valid reason not to, prefer single quotes such that HTML contained therein does not need to be escaped. For example:
+
+      ```
+    // good...
+    var foo = 'Just a normal string';
+
+    // good...
+    var foo = '<a href="/bar">Nice clean HTML string</a>';
+
+    // not good...
+    var foo = "<a href=\"/bar\">HTML string with escaped double quotes</a>";
+
+    ```
 
 - Use `event.preventDefault();` instead of `return false;` to prevent default event actions. Returning a boolean value is semantically incorrect when considering the context is an event.
 


### PR DESCRIPTION
Given that we JSHint our code, we often run into inconsistencies between quoting styles between authors. I may edit a file which mainly uses double quotes, and out of habit insert a single quote thereby triggerring the JSHint validation.

It's easily fixed of course, and in the above situation I am the one "at fault" but I think it would be nice to have a preference indicated as part of the house style so that we are on the same page.

So, this PR represents my preference for single quotes, due to the ability for single quoted strings to contain html without the need for escaping quoted attributes.

Discuss.